### PR TITLE
Submodule testcase_compiler into dwarf_explore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testcase-compiler"]
+	path = testcase-compiler
+	url = git@github.com:jdginn/testcase-compiler.git

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,7 +11,7 @@ import (
 // is to simply compile a testcase. I am using this: https://github.com/jdginn/testcase-compiler
 
 // The downside here is that these tests are hostage to changes in that testcase.
-var testcaseFilename = "../testcase-compiler/main.out.dSYM/Contents/Resources/DWARF/main.out"
+var testcaseFilename = "testcase-compiler/testcase.out.dSYM/Contents/Resources/DWARF/testcase.out"
 
 func TestGetReader(t *testing.T) {
 	// For now, just assume testcase is always located in the right place
@@ -37,7 +37,7 @@ func shouldFailGetEntry(t *testing.T, requestedName string, errorString string) 
 
 func TestGetEntry(t *testing.T) {
 	testGetEntry(t, "formula_1_teams")
-	testGetEntry(t, "main.cpp")
+	testGetEntry(t, "testcase.cpp")
 	testGetEntry(t, "Driver")
 	testGetEntry(t, "Driver")
 	shouldFailGetEntry(t, "badname", "entry could not be found")


### PR DESCRIPTION
I'd like to avoid carrying binaries around but would also like to keep
dwarf_explore separate from the testcase compiler (as that may be used
for other projects in the future and really falls outside the scope of
dwarf_explore).

So now we submodule the testcase compiler and rely on the user (or test
runner) to compile it with clang. The dwarf_explore tests can now point
to the compiled testcase in an expected location.