### PR TITLE
Rename module to reflect new repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[![Coverage Status](https://coveralls.io/repos/github/jdginn/dwarf-explore/badge.svg?branch=cover)](https://coveralls.io/github/jdginn/dwarf-explore?branch=cover)
+[![Coverage Status](https://coveralls.io/repos/github/jdginn/durins-door/badge.svg?branch=cover)](https://coveralls.io/github/jdginn/durins-door?branch=cover)
 
-# Dwarf-explore is a Rosetta stone for programming languages using DWARF
+# Durins-door is a Rosetta stone for programming languages using DWARF

--- a/client/file/file_test.go
+++ b/client/file/file_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jdginn/dwarf-explore/client"
-	"github.com/jdginn/dwarf-explore/client/file"
+	"github.com/jdginn/durins-door/client"
+	"github.com/jdginn/durins-door/client/file"
 )
 
 var testcaseDwarfFile = "../../testcase-compiler/testcase.dwarf"

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -4,9 +4,9 @@ import (
 	"debug/dwarf"
 	"strings"
 
-	"github.com/jdginn/dwarf-explore/client"
-	"github.com/jdginn/dwarf-explore/explorer/plat"
-	"github.com/jdginn/dwarf-explore/parser"
+	"github.com/jdginn/durins-door/client"
+	"github.com/jdginn/durins-door/explorer/plat"
+	"github.com/jdginn/durins-door/parser"
 )
 
 // Struct that mediates DWARF parsing as well as reading and writing

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jdginn/dwarf-explore
+module github.com/jdginn/durins-door
 
 go 1.18
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jdginn/dwarf-explore/explorer/plat"
+	"github.com/jdginn/durins-door/explorer/plat"
 )
 
 // For now, this functionality all relies upon having a reader object. The only good

--- a/parser/proxies.go
+++ b/parser/proxies.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	// "strings"
 
-	"github.com/jdginn/dwarf-explore/client"
+	"github.com/jdginn/durins-door/client"
 )
 
 // A TypedefProxy is an outward-facing representation of a typedef representing what a user


### PR DESCRIPTION
This repository is now named durins-door. This commit renames the
module accordingly.